### PR TITLE
refactor: split todos routes into controller and service layers (#12)

### DIFF
--- a/server/controllers/todos.controller.js
+++ b/server/controllers/todos.controller.js
@@ -1,0 +1,97 @@
+// server/controllers/todos.controller.js
+const { body, validationResult } = require('express-validator');
+const todoService = require('../services/todos.service');
+
+// Validation rules
+exports.validateCreate = [
+  body('title').isString().trim().notEmpty().withMessage('title is required'),
+  body('status').optional().isIn(['pending', 'in-progress', 'completed']),
+];
+
+exports.validateUpdate = [
+  body('title').optional().isString().trim().notEmpty(),
+  body('status').optional().isIn(['pending', 'in-progress', 'completed']),
+];
+
+// Common validation check
+exports.handleValidation = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      error: 'Validation error',
+      details: errors.array(),
+    });
+  }
+  next();
+};
+
+// CREATE
+exports.createTodo = async (req, res) => {
+  try {
+    const todo = await todoService.createTodo(req.body);
+    res.status(201).json(todo);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+};
+
+// READ
+exports.getTodos = async (req, res, next) => {
+  try {
+    const { status, tag, q, sort = 'createdAt:desc', page = '1', limit = '20' } = req.query;
+
+    const pageNum = Math.max(parseInt(page, 10) || 1, 1);
+    const limitNum = Math.min(Math.max(parseInt(limit, 10) || 20, 1), 100);
+
+    const allowSort = new Set(['createdAt', 'updatedAt', 'dueDate', 'title', 'status']);
+    const [rawField, rawDir] = String(sort).split(':');
+    const sortField = allowSort.has(rawField) ? rawField : 'createdAt';
+    const sortDir = rawDir === 'asc' ? 1 : -1;
+    const sortObj = { [sortField]: sortDir };
+
+    const query = {};
+    if (status) query.status = status;
+    if (tag) {
+      const tags = String(tag)
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+      if (tags.length) query.tags = { $in: tags };
+    }
+    if (q && String(q).trim()) {
+      query.title = { $regex: String(q).trim(), $options: 'i' };
+    }
+
+    const { items, total } = await todoService.getTodos(query, { sortObj, pageNum, limitNum });
+
+    res.json({
+      items,
+      page: pageNum,
+      limit: limitNum,
+      total,
+      pages: Math.ceil(total / limitNum),
+      sort: `${sortField}:${sortDir === 1 ? 'asc' : 'desc'}`,
+      filters: { status: status || null, tag: tag || null, q: q || null },
+    });
+  } catch (e) {
+    next(e);
+  }
+};
+
+// UPDATE
+exports.updateTodo = async (req, res) => {
+  try {
+    const updated = await todoService.updateTodo(req.params.id, req.body);
+    if (!updated) return res.status(404).json({ error: 'Not found' });
+    res.json(updated);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+};
+
+// DELETE
+exports.deleteTodo = async (req, res) => {
+  const deleted = await todoService.deleteTodo(req.params.id);
+  if (!deleted) return res.status(404).json({ error: 'Not found' });
+  res.status(204).end();
+};

--- a/server/routes/todos.js
+++ b/server/routes/todos.js
@@ -1,122 +1,25 @@
 // server/routes/todos.js
 const express = require('express');
-const { body, validationResult } = require('express-validator');
-const Todo = require('../models/todo');
+const controller = require('../controllers/todos.controller');
+
 const router = express.Router();
 
-// 共通: バリデーション結果をチェック
-const handleValidation = (req, res, next) => {
-  const errors = validationResult(req);
-  if (!errors.isEmpty()) {
-    return res.status(400).json({
-      error: 'Validation error',
-      details: errors.array()
-    });
-  }
-  next();
-};
-
-// CREATE  (POST /todos)
 router.post(
   '/',
-  [
-    body('title').isString().trim().notEmpty().withMessage('title is required'),
-    body('status').optional().isIn(['pending', 'in-progress', 'completed'])
-  ],
-  handleValidation,
-  async (req, res) => {
-    try {
-      const todo = await Todo.create(req.body);
-      res.status(201).json(todo);
-    } catch (e) {
-      res.status(400).json({ error: e.message });
-    }
-  }
+  controller.validateCreate,
+  controller.handleValidation,
+  controller.createTodo
 );
 
-// READ (GET /todos) 一覧取得 + 検索/ソート/ページング
-router.get('/', async (req, res, next) => {
-  try {
-    const {
-      status,
-      tag,
-      q,
-      sort = 'createdAt:desc',
-      page = '1',
-      limit = '20',
-    } = req.query;
+router.get('/', controller.getTodos);
 
-    // バリデーション/サニタイズ
-    const pageNum = Math.max(parseInt(page, 10) || 1, 1);
-    const limitNum = Math.min(Math.max(parseInt(limit, 10) || 20, 1), 100);
-
-    const allowSort = new Set(['createdAt', 'updatedAt', 'dueDate', 'title', 'status']);
-    const [rawField, rawDir] = String(sort).split(':');
-    const sortField = allowSort.has(rawField) ? rawField : 'createdAt';
-    const sortDir = rawDir === 'asc' ? 1 : -1;
-    const sortObj = { [sortField]: sortDir };
-
-    // クエリ組み立て
-    const query = {};
-    if (status) query.status = status; // 'pending' | 'in-progress' | 'completed'
-    if (tag) {
-      const tags = String(tag).split(',').map(s => s.trim()).filter(Boolean);
-      if (tags.length) query.tags = { $in: tags };
-    }
-    if (q && String(q).trim()) {
-      // 部分一致（ケース無視）
-      query.title = { $regex: String(q).trim(), $options: 'i' };
-      // text indexを使う場合の代替:
-      // query.$text = { $search: String(q).trim() };
-    }
-
-    const [items, total] = await Promise.all([
-      Todo.find(query).sort(sortObj).skip((pageNum - 1) * limitNum).limit(limitNum),
-      Todo.countDocuments(query),
-    ]);
-
-    res.json({
-      items,
-      page: pageNum,
-      limit: limitNum,
-      total,
-      pages: Math.ceil(total / limitNum),
-      sort: `${sortField}:${sortDir === 1 ? 'asc' : 'desc'}`,
-      filters: { status: status || null, tag: tag || null, q: q || null },
-    });
-  } catch (e) {
-    next(e);
-  }
-});
-
-// UPDATE (PUT /todos/:id)
 router.put(
   '/:id',
-  [
-    body('title').optional().isString().trim().notEmpty(),
-    body('status').optional().isIn(['pending', 'in-progress', 'completed'])
-  ],
-  handleValidation,
-  async (req, res) => {
-    try {
-      const updated = await Todo.findByIdAndUpdate(
-        req.params.id,
-        req.body,
-        { new: true, runValidators: true }
-      );
-      if (!updated) return res.status(404).json({ error: 'Not found' });
-      res.json(updated);
-    } catch (e) {
-      res.status(400).json({ error: e.message });
-    }
-  }
+  controller.validateUpdate,
+  controller.handleValidation,
+  controller.updateTodo
 );
 
-// DELETE (DELETE /todos/:id)
-router.delete('/:id', async (req, res) => {
-  const deleted = await Todo.findByIdAndDelete(req.params.id);
-  if (!deleted) return res.status(404).json({ error: 'Not found' });
-  res.status(204).end();
-});
+router.delete('/:id', controller.deleteTodo);
 
 module.exports = router;

--- a/server/services/todos.service.js
+++ b/server/services/todos.service.js
@@ -1,0 +1,29 @@
+// server/services/todos.service.js
+const Todo = require('../models/todo');
+
+exports.createTodo = async (data) => {
+  return await Todo.create(data);
+};
+
+exports.getTodos = async (query, options) => {
+  const { sortObj, pageNum, limitNum } = options;
+  const [items, total] = await Promise.all([
+    Todo.find(query)
+      .sort(sortObj)
+      .skip((pageNum - 1) * limitNum)
+      .limit(limitNum),
+    Todo.countDocuments(query),
+  ]);
+  return { items, total };
+};
+
+exports.updateTodo = async (id, data) => {
+  return await Todo.findByIdAndUpdate(id, data, {
+    new: true,
+    runValidators: true,
+  });
+};
+
+exports.deleteTodo = async (id) => {
+  return await Todo.findByIdAndDelete(id);
+};


### PR DESCRIPTION
### Summary
This PR refactors the todos API routes into layered architecture.

- Added `controllers/todos.controller.js`
  - request validation
  - building query/filter/sort/pagination response
  - error handling / 4xx responses

- Added `services/todos.service.js`
  - all direct DB operations using the Todo model
  - create / query / update / delete logic isolated for reuse and testing

- Updated `routes/todos.js`
  - now only wires HTTP routes to controller methods
  - no business logic in the route layer

### Why
- Improves maintainability and testability
- Keeps responsibilities separated (routing vs controller vs service)
- Matches the project architecture direction described in #12

Closes #12