### PR TITLE
Add restart policy to Docker services (#46)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ services:
   api:
     build: .
     container_name: todo-api
+    restart: unless-stopped
     ports:
       - '3000:3000'
     env_file:
@@ -13,6 +14,7 @@ services:
   mongo:
     image: mongo:7
     container_name: todo-mongo
+    restart: unless-stopped
     ports:
       - '27017:27017'
     environment:


### PR DESCRIPTION
This PR adds automatic restart policies to both API and Mongo services.

### What was changed
- Added `restart: unless-stopped` to `api` and `mongo` in docker-compose.yml

### Why
- Ensures services automatically recover from crashes or server reboot
- Still allows manual stop via `docker compose stop` (unlike `always`)

### Issue
Closes #46