### PR TITLE
docs: document .env.docker usage and env separation (Issue #45)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -169,12 +169,26 @@ cp .env.docker .env
 
 ## 🔑 環境変数
 
-.env.example を参考に .env ファイルを作成します：
+### ローカル実行時（`.env`）
+
+.env.example を参考に .env ファイルを作成し、ホストで `npm run dev` / `npm start` するときに使います：
 
 ```bash
 MONGODB_URI=mongodb://localhost:27017/todo-api
 PORT=3000
 NODE_ENV=development
+```
+
+### Docker 実行時（`.env.docker`）
+
+- 目的: Docker 専用の環境変数ファイル（`docker-compose` の `env_file: .env.docker` でコンテナに適用）
+- 違い: `.env` はホスト実行用、`.env.docker` は Docker 用、`.env.example` は両方のひな型
+- 優先度: 実行時の `docker compose run ... -e KEY=VAL` > `.env.docker` > アプリのデフォルト値
+- 混同防止: ホストは `.env`、コンテナは `.env.docker` を使い分ける。編集後は必ず再起動する：
+
+```bash
+docker compose down
+docker compose up -d
 ```
 
 ## 📡 APIリファレンス

--- a/README.md
+++ b/README.md
@@ -167,12 +167,26 @@ It will be added as part of roadmap milestone “v0.3 – CI & Testing”.
 
 ## 🔑 Environment Variables
 
-Create a .env file based on .env.example:
+### Local execution (`.env`)
+
+Create a .env file based on .env.example for running `npm run dev` / `npm start` on the host:
 
 ```bash
 MONGODB_URI=mongodb://localhost:27017/todo-api
 PORT=3000
 NODE_ENV=development
+```
+
+### Docker execution (`.env.docker`)
+
+- Purpose: Docker-specific env file applied via `docker-compose` `env_file: .env.docker` so containers get the right settings.
+- Differences: `.env` is for host runs, `.env.docker` is for Docker runs, `.env.example` is the template for both.
+- Priority: `docker compose run ... -e KEY=VAL` > `.env.docker` > app defaults.
+- Avoid mixing: use `.env` for host-only runs and `.env.docker` for container runs. After editing `.env.docker`, restart the stack:
+
+```bash
+docker compose down
+docker compose up -d
 ```
 
 ## 📡 API Reference


### PR DESCRIPTION
## What
- Added clear documentation for `.env.docker` in both README.md and README.ja.md
- Clarified differences between `.env`, `.env.docker`, and `.env.example`
- Explained environment variable override rules in Docker
- Added tips to avoid mixing local and Docker environments

## Why
- Prevent confusion between local and Docker execution
- Make environment setup clearer for new contributors

## Notes
- Documentation-only change
- No tests were run