### PR TITLE
Add Makefile for common Docker commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,16 @@
-# ==========================
-# Makefile for todo-api
-# ==========================
+.PHONY: up down logs restart seed
 
-# Shortcut to start containers
 up:
 	docker compose up -d
 
-# Start with build (for first time)
-build:
-	docker compose up --build -d
-
-# Stop containers
 down:
 	docker compose down
 
-# Restart containers
-restart:
-	docker compose down
-	docker compose up -d
-
-# Show logs (API)
 logs:
-	docker logs -f todo-api
+	docker compose logs -f
 
-# Show logs (Mongo)
-mongo-logs:
-	docker logs -f todo-mongo
+restart:
+	docker compose down && docker compose up -d
 
-# Open Mongo shell
-mongo:
-	docker exec -it todo-mongo mongosh
-
-# Remove all containers + volumes (dangerous)
-clean:
-	docker compose down --volumes --remove-orphans
+seed:
+	docker compose exec api npm run seed

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,8 @@
 ## 📋 目次
 
 - [クイックスタート](#-クイックスタート)
+- [使い方](#-使い方)
+- [Makefile コマンド](#-makefile-コマンド)
 - [使用技術（Tech Stack）](#-使用技術tech-stack)
 - [環境変数](#-環境変数)
 - [APIリファレンス](#-apiリファレンス)
@@ -148,6 +150,20 @@ Docker 開発用には .env.docker を使用します。
 ```bash
 cp .env.docker .env
 ```
+
+
+## 📦 使い方
+
+リポジトリ直下で Docker Compose を使ってスタックを動かしてください。
+
+## 🛠️ Makefile コマンド
+
+すべてリポジトリ直下で実行します：
+- `make up` — スタックをバックグラウンドで起動
+- `make down` — コンテナを停止して削除
+- `make logs` — すべてのサービスのログを追跡
+- `make restart` — 一度停止してから再起動
+- `make seed` — `api` サービス内で `npm run seed` を実行
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project serves as a foundation for building robust backend APIs with a clea
 ## 📋 Table of Contents
 
 - [Quick Start](#-quick-start)
+- [Usage](#-usage)
+- [Makefile Commands](#-makefile-commands)
 - [Tech Stack](#-tech-stack)
 - [Environment Variables](#-environment-variables)
 - [API Reference](#-api-reference)
@@ -148,6 +150,19 @@ To customize:
 ```bash
 cp .env.docker .env
 ```
+
+## 📦 Usage
+
+Run the Docker-based stack from the repository root with Docker Compose.
+
+## 🛠️ Makefile Commands
+
+Use these shortcuts from the repository root:
+- `make up` — start the stack in detached mode.
+- `make down` — stop and remove the stack.
+- `make logs` — follow combined service logs.
+- `make restart` — recreate the stack by stopping then starting.
+- `make seed` — run `npm run seed` inside the `api` service.
 
 ## 🧰 Tech Stack
 


### PR DESCRIPTION
Implements Issue #44.

- Adds a root Makefile with common docker compose shortcuts
- All targets are phony and use existing docker-compose.yml
- Documents Makefile usage in README.md and README.ja.md