### PR TITLE
feat: add board-scoped todos endpoint and align API docs (Issue #10)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -211,13 +211,14 @@ docker compose up -d
 
 Base URL: http://localhost:3000
 
-| メソッド | パス         | 説明           | Body（JSON）                                              |       |                         |
-| :------- | :----------- | :------------- | :-------------------------------------------------------- | ----- | ----------------------- |
-| GET      | `/todos`     | ToDo一覧を取得 | —                                                         |       |                         |
-| POST     | `/todos`     | ToDoを作成     | `{ "title": "string", "description": "?", "status": "todo | doing | done", "tags": ["?"] }` |
-| GET      | `/todos/:id` | ID指定で取得   | —                                                         |       |                         |
-| PUT      | `/todos/:id` | ToDoを更新     | POSTと同様                                                |       |                         |
-| DELETE   | `/todos/:id` | ToDoを削除     | —                                                         |       |                         |
+| メソッド | パス | 説明 | Body (JSON) |
+| :----- | :--- | :--- | :---------- |
+| GET | `/todos` | Todo一覧を取得 | — |
+| GET | `/boards/:boardId/todos` | Board別のTodo一覧を取得 | — |
+| POST | `/todos` | Todoを作成 | `{ "title": "string", "description": "?", "status": "todo | doing | done", "tags": ["?"] }` |
+| GET | `/todos/:id` | IDを指定してTodoを取得 | — |
+| PUT | `/todos/:id` | Todoを更新 | POSTと同じ |
+| DELETE | `/todos/:id` | Todoを削除 | — |
 
 ✅ バリデーションは express-validator によりルート定義時に実行されます。
 
@@ -233,6 +234,22 @@ curl -X POST http://localhost:3000/todos \
 
 ```bash
 curl "http://localhost:3000/todos?status=pending&tag=work,urgent&q=readme&sort=dueDate:asc&page=1&limit=10"
+```
+
+### Board別のTodo取得（NexusBoard連携）
+
+NexusBoardでは、Boardを単位としてTodoの一覧を扱います。
+そのため、Boardを主軸とした一覧取得用のエンドポイントを正規（canonical）として定義しています。
+
+```bash
+curl http://localhost:3000/boards/<boardId>/todos
+```
+
+後方互換性を保つため、GET /todos?boardId=<id> も同じ結果を返します。
+どちらのエンドポイントも、以下の形式でレスポンスを返します。
+
+```json
+{ "todos": [...] }
 ```
 
 ## 🗂️ プロジェクト構成

--- a/README.md
+++ b/README.md
@@ -221,13 +221,14 @@ docker compose up -d
 
 Base URL: http://localhost:3000
 
-| Method | Path         | Description      | Body (JSON)                                               |       |                         |
-| :----- | :----------- | :--------------- | :-------------------------------------------------------- | ----- | ----------------------- |
-| GET    | `/todos`     | List all todos   | —                                                         |       |                         |
-| POST   | `/todos`     | Create a todo    | `{ "title": "string", "description": "?", "status": "todo | doing | done", "tags": ["?"] }` |
-| GET    | `/todos/:id` | Get a todo by ID | —                                                         |       |                         |
-| PUT    | `/todos/:id` | Update a todo    | same as POST                                              |       |                         |
-| DELETE | `/todos/:id` | Delete a todo    | —                                                         |       |                         |
+| Method | Path | Description | Body (JSON) |
+| :----- | :--- | :---------- | :---------- |
+| GET | `/todos` | List all todos | — |
+| GET | `/boards/:boardId/todos` | List todos in a board | — |
+| POST | `/todos` | Create a todo | `{ "title": "string", "description": "?", "status": "todo | doing | done", "tags": ["?"] }` |
+| GET | `/todos/:id` | Get a todo by ID | — |
+| PUT | `/todos/:id` | Update a todo | same as POST |
+| DELETE | `/todos/:id` | Delete a todo | — |
 
 ✅ Validation handled via express-validator in route definitions.
 
@@ -243,6 +244,20 @@ curl -X POST http://localhost:3000/todos \
 
 ```bash
 curl "http://localhost:3000/todos?status=pending&tag=work,urgent&q=readme&sort=dueDate:asc&page=1&limit=10"
+```
+
+### Board-scoped todos (NexusBoard integration)
+
+Boards are treated as the primary resource for board-specific lists. The canonical endpoint is:
+
+```bash
+curl http://localhost:3000/boards/<boardId>/todos
+```
+
+For backward compatibility, `GET /todos?boardId=<id>` returns the same result. Both endpoints respond with:
+
+```json
+{ "todos": [...] }
 ```
 
 ## 🗂️ Project Structure

--- a/server/app.js
+++ b/server/app.js
@@ -6,6 +6,7 @@ import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 
 import todosRouter from './routes/todos.js';
+import boardsRouter from './routes/boards.js';
 import errorHandler from './middlewares/error.js';
 import userRoutes from '../routes/userRoutes.js';
 import config from './config/index.js';
@@ -41,6 +42,7 @@ export function createApp() {
 
   // --- ルーター ---
   app.use('/todos', todosRouter);
+  app.use('/boards', boardsRouter);
   app.use('/users', userRoutes);
 
   // --- エラーハンドラ ---

--- a/server/controllers/todos.controller.js
+++ b/server/controllers/todos.controller.js
@@ -71,7 +71,19 @@ export const createTodo = async (req, res) => {
 export const getTodos = async (req, res, next) => {
   try {
     // クエリパラメータから検索条件や並び順、ページ番号などを取得
-    const { status, tag, q, sort = 'createdAt:desc', page = '1', limit = '20' } = req.query;
+    const {
+      status,
+      tag,
+      q,
+      sort = 'createdAt:desc',
+      page = '1',
+      limit = '20',
+      boardId,
+    } = req.query;
+    if (boardId) {
+      const todos = await todoService.getTodosByBoardId(String(boardId));
+      return res.json({ todos });
+    }
 
     // ページネーション処理
     const pageNum = Math.max(parseInt(page, 10) || 1, 1);
@@ -113,6 +125,19 @@ export const getTodos = async (req, res, next) => {
     });
   } catch (e) {
     next(e); // エラーハンドラに渡す
+  }
+};
+
+// ============================================
+// 🔸 4-2. READ（Board別のTodo一覧を取得）
+// ============================================
+export const getTodosByBoardId = async (req, res, next) => {
+  try {
+    const { boardId } = req.params;
+    const todos = await todoService.getTodosByBoardId(String(boardId));
+    res.json({ todos });
+  } catch (e) {
+    next(e);
   }
 };
 

--- a/server/models/todo.js
+++ b/server/models/todo.js
@@ -17,6 +17,7 @@ const todoSchema = new Schema(
       default: 'pending',
     },
     tags: { type: [String], default: [] },
+    boardId: { type: String, index: true },
   },
   { timestamps: true }
 );

--- a/server/routes/boards.js
+++ b/server/routes/boards.js
@@ -1,0 +1,9 @@
+// server/routes/boards.js
+import express from 'express';
+import { getTodosByBoardId } from '../controllers/todos.controller.js';
+
+const router = express.Router();
+
+router.get('/:boardId/todos', getTodosByBoardId);
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -6,6 +6,7 @@ import helmet from 'helmet';
 import rateLimit from 'express-rate-limit';
 import { connectDB } from './config/db.js';
 import todosRouter from './routes/todos.js';
+import boardsRouter from './routes/boards.js';
 import errorHandler from './middlewares/error.js';
 import userRoutes from '../routes/userRoutes.js';
 import config from './config/index.js';
@@ -42,6 +43,7 @@ app.use(express.json());
 
 // ルート
 app.use('/todos', todosRouter);
+app.use('/boards', boardsRouter);
 
 // userRoutes を登録
 app.use('/users', userRoutes);

--- a/server/services/todos.service.js
+++ b/server/services/todos.service.js
@@ -23,6 +23,11 @@ export async function getTodos(query, options) {
   return { items, total };
 }
 
+// READ（Board別のTodo一覧取得）
+export async function getTodosByBoardId(boardId) {
+  return await Todo.find({ boardId }).sort({ createdAt: -1 });
+}
+
 // UPDATE（Todo更新）
 export async function updateTodo(id, data) {
   return await Todo.findByIdAndUpdate(id, data, {


### PR DESCRIPTION
Implemented board-scoped todos endpoint.

- Added canonical endpoint: GET /boards/:boardId/todos
- Preserved backward compatibility via GET /todos?boardId=<id>
- Reused service layer logic for consistency
- Updated both README.md and README.ja.md with aligned API references

This completes Issue #10.

Closes #10