### PR TITLE
Add priority field with validation and filtering

### DIFF
--- a/server/controllers/todos.controller.js
+++ b/server/controllers/todos.controller.js
@@ -26,12 +26,21 @@ export const validateCreate = [
   body('status') // statusフィールドは任意
     .optional()
     .isIn(['pending', 'in-progress', 'completed']), // 許可された文字列だけ
+
+  body('priority')
+    .optional()
+    .isIn(['low', 'medium', 'high'])
+    .withMessage('priority must be low, medium, or high'),
 ];
 
 // 更新用
 export const validateUpdate = [
   body('title').optional().isString().trim().notEmpty(),
   body('status').optional().isIn(['pending', 'in-progress', 'completed']),
+  body('priority')
+    .optional()
+    .isIn(['low', 'medium', 'high'])
+    .withMessage('priority must be low, medium, or high'),
 ];
 
 // ============================================
@@ -79,6 +88,7 @@ export const getTodos = async (req, res, next) => {
       page = '1',
       limit = '20',
       boardId,
+      priority,
     } = req.query;
     if (boardId) {
       const todos = await todoService.getTodosByBoardId(String(boardId));
@@ -99,6 +109,7 @@ export const getTodos = async (req, res, next) => {
     // 検索条件を組み立て
     const query = {};
     if (status) query.status = status;
+    if (priority) query.priority = priority;
     if (tag) {
       const tags = String(tag)
         .split(',')
@@ -121,7 +132,12 @@ export const getTodos = async (req, res, next) => {
       total,
       pages: Math.ceil(total / limitNum),
       sort: `${sortField}:${sortDir === 1 ? 'asc' : 'desc'}`,
-      filters: { status: status || null, tag: tag || null, q: q || null },
+      filters: {
+        status: status || null,
+        tag: tag || null,
+        priority: priority || null,
+        q: q || null,
+      },
     });
   } catch (e) {
     next(e); // エラーハンドラに渡す

--- a/server/models/todo.js
+++ b/server/models/todo.js
@@ -16,6 +16,11 @@ const todoSchema = new Schema(
       enum: ['pending', 'in-progress', 'completed'],
       default: 'pending',
     },
+    priority: {
+      type: String,
+      enum: ['low', 'medium', 'high'],
+      default: 'medium',
+    },
     tags: { type: [String], default: [] },
     boardId: { type: String, index: true },
   },

--- a/tests/todos.test.js
+++ b/tests/todos.test.js
@@ -75,4 +75,58 @@ describe('Todos API', () => {
     const res = await request(app).get('/todos').expect(200);
     assert.equal(res.body.total, 0);
   });
+
+  test('creates a todo with priority', async () => {
+    const res = await request(app)
+      .post('/todos')
+      .send({ title: 'High priority task', priority: 'high' })
+      .expect(201);
+
+    assert.equal(res.body.title, 'High priority task');
+    assert.equal(res.body.priority, 'high');
+  });
+
+  test('creates a todo with default priority', async () => {
+    const res = await request(app).post('/todos').send({ title: 'Default priority' }).expect(201);
+
+    assert.equal(res.body.priority, 'medium');
+  });
+
+  test('rejects invalid priority value', async () => {
+    const res = await request(app)
+      .post('/todos')
+      .send({ title: 'Invalid priority', priority: 'urgent' })
+      .expect(400);
+
+    assert.ok(res.body.error);
+  });
+
+  test('filters todos by priority', async () => {
+    await request(app).post('/todos').send({ title: 'Low task', priority: 'low' }).expect(201);
+    await request(app).post('/todos').send({ title: 'High task', priority: 'high' }).expect(201);
+    await request(app)
+      .post('/todos')
+      .send({ title: 'Medium task', priority: 'medium' })
+      .expect(201);
+
+    const res = await request(app).get('/todos?priority=high').expect(200);
+
+    assert.equal(res.body.total, 1);
+    assert.equal(res.body.items[0].title, 'High task');
+    assert.equal(res.body.items[0].priority, 'high');
+  });
+
+  test('updates todo priority', async () => {
+    const created = await request(app)
+      .post('/todos')
+      .send({ title: 'Change priority', priority: 'low' })
+      .expect(201);
+
+    const updated = await request(app)
+      .put(`/todos/${created.body._id}`)
+      .send({ priority: 'high' })
+      .expect(200);
+
+    assert.equal(updated.body.priority, 'high');
+  });
 });


### PR DESCRIPTION
## Summary
This PR adds a `priority` field to the Todo model, enabling users to categorize tasks by urgency.

## Changes
- **Model**: Added `priority` field to Todo schema (`low | medium | high`, default: `medium`)
- **Validation**: Added input validation for `priority` in both create and update operations
- **Filtering**: Enabled filtering todos by `priority` query parameter (e.g., `GET /todos?priority=high`)
- **Response**: Added `priority` to the response `filters` object for client visibility
- **Tests**: Added comprehensive test coverage for priority functionality

## Testing
- ✅ All tests pass (`npm test`)
- ✅ Priority field creation and defaults work correctly
- ✅ Invalid priority values are rejected (400)
- ✅ Filtering by priority works as expected
- ✅ Priority updates work correctly

## API Examples

### Create with priority
```bash
POST /todos
{ "title": "Urgent task", "priority": "high" }
```

### Filter by priority
```bash
GET /todos?priority=high
```

Closes #24