### PR TITLE
Restrict CORS origins in production

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,3 +3,7 @@ MONGODB_URI=mongodb://127.0.0.1:27017/todo_api
 
 # App port
 PORT=3000
+
+# CORS allowed origins (comma-separated, required in production)
+# Example: https://example.com,https://app.example.com
+ALLOWED_ORIGINS=

--- a/server/server.js
+++ b/server/server.js
@@ -38,7 +38,39 @@ app.get('/', (_req, res) => res.json({ ok: true }));
 
 app.get('/health', (_req, res) => res.json({ ok: true }));
 
-app.use(cors());
+// CORS設定: 開発環境は全許可、本番環境はALLOWED_ORIGINSのみ許可
+const corsOptions = {
+  origin: (origin, callback) => {
+    // Non-browser requests (curl, server-to-server) have no origin
+    if (!origin) {
+      return callback(null, true);
+    }
+
+    // Development: allow all origins
+    if (config.nodeEnv !== 'production') {
+      return callback(null, true);
+    }
+
+    // Production: check against ALLOWED_ORIGINS
+    const allowedOrigins = process.env.ALLOWED_ORIGINS
+      ? process.env.ALLOWED_ORIGINS.split(',')
+          .map((o) => o.trim())
+          .filter(Boolean)
+      : [];
+
+    if (allowedOrigins.length === 0) {
+      return callback(new Error('CORS rejected: ALLOWED_ORIGINS not configured for production'));
+    }
+
+    if (allowedOrigins.includes(origin)) {
+      return callback(null, true);
+    }
+
+    return callback(new Error(`CORS rejected: origin ${origin} not allowed`));
+  },
+};
+
+app.use(cors(corsOptions));
 app.use(express.json());
 
 // ルート


### PR DESCRIPTION
## Summary

This PR implements issue #37 by restricting the CORS policy in production while keeping development and non-browser requests unrestricted.

Previously, the server used `app.use(cors())`, which allowed all origins in every environment. This change introduces an environment-aware CORS configuration to improve security in production.

---

## What Changed

### Files modified

* **`server/server.js`**

  * Replaced `cors()` with `cors(corsOptions)` using an `origin` callback
* **`.env.example`**

  * Added `ALLOWED_ORIGINS` environment variable (comma-separated)

---

## CORS Behavior

The CORS decision flow is now:

1. **No `Origin` header** (e.g. curl, Postman, server-to-server)
   → Allowed

2. **Non-production environment** (`NODE_ENV !== "production"`)
   → All origins allowed

3. **Production environment**

   * `ALLOWED_ORIGINS` is empty or not configured
     → Request rejected (fail-safe)
   * `Origin` is included in `ALLOWED_ORIGINS`
     → Allowed
   * `Origin` is not included
     → Rejected

---

## Why This Approach

* Improves API security by restricting browser-based access in production
* Keeps local development friction-free
* Uses a fail-safe design to avoid accidental open CORS in production
* Limits changes strictly to runtime CORS behavior (no config refactoring)

---

## Notes / Assumptions

* Non-browser requests without an `Origin` header are always allowed, as CORS is a browser security mechanism
* `ALLOWED_ORIGINS` is read directly from `process.env` to avoid modifying existing config validation
* No commits have been made without review approval

---

## Related Issue

Closes #37
