### PR TITLE
Tune Content Security Policy (CSP)

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,6 +10,7 @@ import boardsRouter from './routes/boards.js';
 import errorHandler from './middlewares/error.js';
 import userRoutes from '../routes/userRoutes.js';
 import config from './config/index.js';
+import buildCspDirectives from './config/csp.js';
 
 export function createApp() {
   const app = express();
@@ -20,7 +21,17 @@ export function createApp() {
   app.use(morgan('combined'));
 
   // --- セキュリティ ---
-  app.use(helmet());
+  app.use(
+    helmet({
+      contentSecurityPolicy: false,
+    })
+  );
+  app.use(
+    helmet.contentSecurityPolicy({
+      useDefaults: false,
+      directives: buildCspDirectives(),
+    })
+  );
 
   // --- レートリミット（DoS対策）---
   const limiter = rateLimit({

--- a/server/config/csp.js
+++ b/server/config/csp.js
@@ -1,0 +1,48 @@
+// server/config/csp.js
+const splitSources = (value) =>
+  value
+    ? value
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean)
+    : [];
+
+const mergeSources = (defaults, extra) => [...new Set([...defaults, ...extra])];
+
+const buildCspDirectives = () => {
+  const scriptSrc = mergeSources(
+    ["'self'", 'https://cdn.jsdelivr.net', 'https://cdnjs.cloudflare.com'],
+    splitSources(process.env.CSP_SCRIPT_SRC)
+  );
+  const styleSrc = mergeSources(
+    ["'self'", 'https://fonts.googleapis.com', 'https://cdn.jsdelivr.net'],
+    splitSources(process.env.CSP_STYLE_SRC)
+  );
+  const fontSrc = mergeSources(
+    ["'self'", 'https://fonts.gstatic.com', 'https://cdn.jsdelivr.net'],
+    splitSources(process.env.CSP_FONT_SRC)
+  );
+  const imgSrc = mergeSources(
+    ["'self'", 'data:', 'https://cdn.jsdelivr.net', 'https://cdnjs.cloudflare.com'],
+    splitSources(process.env.CSP_IMG_SRC)
+  );
+  const connectSrc = mergeSources(
+    ["'self'"],
+    splitSources(process.env.CSP_CONNECT_SRC)
+  );
+
+  return {
+    defaultSrc: ["'self'"],
+    scriptSrc,
+    styleSrc,
+    fontSrc,
+    imgSrc,
+    connectSrc,
+    objectSrc: ["'none'"],
+    baseUri: ["'self'"],
+    frameAncestors: ["'none'"],
+    formAction: ["'self'"],
+  };
+};
+
+export default buildCspDirectives;

--- a/server/server.js
+++ b/server/server.js
@@ -10,6 +10,7 @@ import boardsRouter from './routes/boards.js';
 import errorHandler from './middlewares/error.js';
 import userRoutes from '../routes/userRoutes.js';
 import config from './config/index.js';
+import buildCspDirectives from './config/csp.js';
 
 console.log('🌱 NODE_ENV:', config.nodeEnv);
 
@@ -24,7 +25,18 @@ app.use(morgan('combined'));
 
 // セキュリティヘッダーを有効化
 // HSTS is disabled by default and enabled only in production (see below)
-app.use(helmet({ hsts: false }));
+app.use(
+  helmet({
+    hsts: false,
+    contentSecurityPolicy: false,
+  })
+);
+app.use(
+  helmet.contentSecurityPolicy({
+    useDefaults: false,
+    directives: buildCspDirectives(),
+  })
+);
 
 // HSTS (HTTP Strict-Transport-Security): 本番環境のみ有効化
 // 開発・テスト環境ではHTTPSが利用できないことがあるため、HSTSを無効にする


### PR DESCRIPTION
## Resolution Summary

The Content Security Policy (CSP) configuration has been reviewed and updated.

### What was confirmed

* CSP directives are explicitly defined using Helmet.
* No wildcard (`*`) sources are present in default directives.
* No broad scheme sources such as `https:` or `http:` are used.
* All external resources are allowed via fully-qualified domain names only.
* Defaults are restrictive and align with CSP best practices.

### Security Review Notes

* Environment variable overrides (`CSP_*`) can theoretically weaken CSP if misused.
  This is considered a trust-boundary concern and should be handled with care in production.
* `data:` is allowed in `img-src` intentionally for base64-encoded images.
* Additional hardening options (e.g. CSP reporting, `upgrade-insecure-requests`) were considered but are out of scope for this issue.

### Conclusion

The original goals of issue #38 have been met.
The CSP is now explicit, minimal, and secure enough for current requirements.

Closing this issue.
