### PR TITLE
Exclude /health from rate limiting

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -38,6 +38,7 @@ export function createApp() {
     windowMs: 15 * 60 * 1000,
     max: 100,
     message: 'Too many requests, please try again later.',
+    skip: (req) => req.path === '/health',
   });
   app.use(limiter);
 

--- a/server/server.js
+++ b/server/server.js
@@ -54,6 +54,7 @@ const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15分
   max: 100, // 各IPごとに最大100リクエスト
   message: 'Too many requests, please try again later.',
+  skip: (req) => req.path === '/health',
 });
 app.use(limiter);
 


### PR DESCRIPTION
## Summary
Exclude the `/health` endpoint from rate limiting to prevent false alerts from monitoring systems.

## Details
- Use express-rate-limit official `skip` option
- Match `/health` using `req.path`
- No changes to existing rate limit configuration

Closes #40