### PR TITLE
feat(auth): add refresh token endpoint and JWT helpers

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -9,6 +9,7 @@ import todosRouter from './routes/todos.js';
 import boardsRouter from './routes/boards.js';
 import errorHandler from './middlewares/error.js';
 import userRoutes from '../routes/userRoutes.js';
+import authRoutes from './routes/auth.js';
 import config from './config/index.js';
 import buildCspDirectives from './config/csp.js';
 
@@ -53,6 +54,7 @@ export function createApp() {
   app.use(express.json());
 
   // --- ルーター ---
+  app.use('/auth', authRoutes);
   app.use('/todos', todosRouter);
   app.use('/boards', boardsRouter);
   app.use('/', userRoutes);

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -1,0 +1,53 @@
+// server/controllers/auth.controller.js
+import { body, validationResult } from 'express-validator';
+import { createAccessToken, verifyRefreshToken } from '../services/auth.service.js';
+
+export const validateRefresh = [
+  body('refreshToken')
+    .isString()
+    .trim()
+    .notEmpty()
+    .withMessage('refreshToken is required'),
+];
+
+export const handleValidation = (req, res, next) => {
+  const errors = validationResult(req);
+  if (!errors.isEmpty()) {
+    return res.status(400).json({
+      error: 'Validation error',
+      details: errors.array(),
+    });
+  }
+  return next();
+};
+
+export const refreshAccessToken = async (req, res, next) => {
+  try {
+    const { refreshToken } = req.body;
+    const payload = verifyRefreshToken(refreshToken);
+
+    if (payload.tokenType && payload.tokenType !== 'refresh') {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+
+    const {
+      tokenType,
+      iat,
+      exp,
+      nbf,
+      iss,
+      aud,
+      sub,
+      jti,
+      ...userPayload
+    } = payload;
+
+    const accessToken = createAccessToken(userPayload);
+    return res.json({ accessToken, tokenType: 'Bearer' });
+  } catch (e) {
+    if (e.name === 'TokenExpiredError' || e.name === 'JsonWebTokenError') {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
+    return next(e);
+  }
+};

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -16,6 +16,9 @@ export default function auth(req, res, next) {
 
   try {
     const payload = jwt.verify(token, secret);
+    if (payload.tokenType && payload.tokenType !== 'access') {
+      return res.status(401).json({ error: 'Invalid token' });
+    }
     req.user = payload;
     return next();
   } catch (err) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -1,0 +1,14 @@
+// server/routes/auth.js
+import express from 'express';
+import asyncHandler from '../../utils/asyncHandler.js';
+import {
+  refreshAccessToken,
+  validateRefresh,
+  handleValidation,
+} from '../controllers/auth.controller.js';
+
+const router = express.Router();
+
+router.post('/refresh', validateRefresh, handleValidation, asyncHandler(refreshAccessToken));
+
+export default router;

--- a/server/server.js
+++ b/server/server.js
@@ -9,6 +9,7 @@ import todosRouter from './routes/todos.js';
 import boardsRouter from './routes/boards.js';
 import errorHandler from './middlewares/error.js';
 import userRoutes from '../routes/userRoutes.js';
+import authRoutes from './routes/auth.js';
 import config from './config/index.js';
 import buildCspDirectives from './config/csp.js';
 
@@ -105,6 +106,7 @@ app.use(cors(corsOptions));
 app.use(express.json());
 
 // ルート
+app.use('/auth', authRoutes);
 app.use('/todos', todosRouter);
 app.use('/boards', boardsRouter);
 

--- a/server/services/auth.service.js
+++ b/server/services/auth.service.js
@@ -1,0 +1,33 @@
+// server/services/auth.service.js
+import jwt from 'jsonwebtoken';
+
+const ACCESS_EXPIRES_IN = process.env.JWT_ACCESS_EXPIRES_IN || '15m';
+const REFRESH_EXPIRES_IN = process.env.JWT_REFRESH_EXPIRES_IN || '7d';
+
+const getAccessSecret = () => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET is not configured');
+  }
+  return secret;
+};
+
+const getRefreshSecret = () => {
+  const secret = process.env.JWT_REFRESH_SECRET || process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_REFRESH_SECRET is not configured');
+  }
+  return secret;
+};
+
+export const createAccessToken = (payload) =>
+  jwt.sign({ ...payload, tokenType: 'access' }, getAccessSecret(), {
+    expiresIn: ACCESS_EXPIRES_IN,
+  });
+
+export const createRefreshToken = (payload) =>
+  jwt.sign({ ...payload, tokenType: 'refresh' }, getRefreshSecret(), {
+    expiresIn: REFRESH_EXPIRES_IN,
+  });
+
+export const verifyRefreshToken = (token) => jwt.verify(token, getRefreshSecret());


### PR DESCRIPTION
### Motivation
- Implement a server-side refresh-token flow so clients can exchange a long-lived refresh token for a short-lived access token and avoid logging in repeatedly.
- Ensure token-type separation so refresh tokens cannot be used on access-protected routes and access tokens are not accepted where a refresh token is expected.

### Description
- Added `server/services/auth.service.js` with `createAccessToken`, `createRefreshToken`, and `verifyRefreshToken`, and separate secrets/expiry configuration via `JWT_SECRET`/`JWT_REFRESH_SECRET` and env vars.
- Added `server/controllers/auth.controller.js` with validation and `refreshAccessToken` to verify a refresh token and return a new access token (`/auth/refresh`).
- Added `server/routes/auth.js` and registered the auth routes in both `server/app.js` and `server/server.js` under `app.use('/auth', ...)`.
- Hardened `server/middlewares/auth.js` to reject tokens whose `tokenType` is not `access`, preventing refresh tokens from being used on protected endpoints.

### Testing
- No automated tests were executed as part of this change (no `npm test` or CI run was performed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988059e6d4883259e17c928ca70e498)