### PR TITLE
test: add Jest + Supertest minimal test suite (#7)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -356,15 +356,20 @@ todo-api/
 npm run dev     # nodemonで開発モード起動
 npm start       # 通常起動（本番想定）
 npm run lint    # ESLint + Prettierチェック
-npm test        # node:test スイート実行
+npm test        # Jest + Supertest テスト実行
 ```
 
 個別テスト実行:
 
 ```bash
-node --test tests/todos.test.js
-node --test tests/auth.test.js
+npx jest tests/todos.test.js --runInBand
+npx jest tests/smoke.e2e.test.js --runInBand
 ```
+
+Issue #7 のテスト範囲:
+- `tests/todos.test.js`: Todo CRUD の happy path と代表的な validation error を確認
+- `tests/smoke.e2e.test.js`: `create -> list -> update -> delete` の通しシナリオを確認
+- `tests/auth.test.js` は `node:test` ベースの既存テストとして別実行
 
 ### マイグレーション（#77）
 

--- a/README.md
+++ b/README.md
@@ -349,15 +349,20 @@ From the repository root:
 npm run dev     # start server with nodemon
 npm start       # start normally (production-like)
 npm run lint    # run ESLint + Prettier checks
-npm test        # run node:test suites
+npm test        # run Jest + Supertest suites
 ```
 
 Targeted test execution:
 
 ```bash
-node --test tests/todos.test.js
-node --test tests/auth.test.js
+npx jest tests/todos.test.js --runInBand
+npx jest tests/smoke.e2e.test.js --runInBand
 ```
+
+Issue #7 test scope:
+- `tests/todos.test.js`: covers Todo CRUD happy paths and a representative validation error.
+- `tests/smoke.e2e.test.js`: covers one end-to-end flow (`create -> list -> update -> delete`).
+- `tests/auth.test.js` still exists as a `node:test` suite and is run separately.
 
 ### Migration script (#77)
 


### PR DESCRIPTION
## Summary

Introduce a minimal automated testing setup using Jest and Supertest.

## Changes

- Add Jest and Supertest
- Switch `npm test` to Jest runner
- Add `tests/todos.test.js`
  - Todo CRUD happy path
  - validation error
- Add `tests/smoke.e2e.test.js`
  - create → list → update → delete flow
- Update README (English and Japanese)
- Clarify that `tests/auth.test.js` remains a `node:test` suite

## Test

Run:

npm install
npm test

Result:

- 2 test suites passed
- 6 tests passed

## Issue

Closes #7