### PR TITLE
feat(error): standardize error response format (#4)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -303,7 +303,7 @@ curl http://localhost:3001/boards/<boardId>/todos \
 ### Refresh Token Reuse Detection（#77）
 
 rotated/revoked 済みの refresh token が再利用された場合、`/auth/refresh` は
-`403` と `errorCode: "REFRESH_TOKEN_REUSE"` を返します。
+`403` と `code: "REFRESH_TOKEN_REUSE"` を返します。
 
 詳細: [docs/auth-refresh-token-reuse.md](./docs/auth-refresh-token-reuse.md)
 
@@ -377,11 +377,13 @@ npm test        # Jest + Supertest テスト実行
 個別テスト実行:
 
 ```bash
-npx jest tests/todos.test.js --runInBand
-npx jest tests/smoke.e2e.test.js --runInBand
+npm run test:file -- tests/errors.test.js
+npm run test:file -- tests/todos.test.js
+npm run test:file -- tests/smoke.e2e.test.js
 ```
 
 Issue #7 のテスト範囲:
+- `tests/errors.test.js`: 統一された `400 / 404 / 500` エラーレスポンスを確認
 - `tests/todos.test.js`: Todo CRUD の happy path と代表的な validation error を確認
 - `tests/smoke.e2e.test.js`: `create -> list -> update -> delete` の通しシナリオを確認
 - `tests/auth.test.js` は `node:test` ベースの既存テストとして別実行
@@ -400,11 +402,39 @@ make seed
 
 ## ⚠️ エラーハンドリング
 
-すべてのエラーは middlewares/error.js で一元管理されます。
+実際の API エラー応答は `server/middlewares/error.js` で一元管理されます。
 
-- 本番環境以外ではスタックトレースを出力
-- 非同期ルートの統一的エラーハンドリングは今後追加予定
-- 400 / 404 / 500 応答は整形済みで、フロント側で扱いやすい形式
+- すべてのエラーレスポンスは `{ error, code, details? }` 形式です。
+- `details` は返す内容がある場合のみ含まれます。
+- 500 系では内部例外の詳細をレスポンスへ露出しません。
+
+Validation エラー例:
+
+```json
+{
+  "error": "Validation error",
+  "code": "VALIDATION_ERROR",
+  "details": [{ "field": "title", "msg": "title is required" }]
+}
+```
+
+Not found 例:
+
+```json
+{
+  "error": "Not found",
+  "code": "NOT_FOUND"
+}
+```
+
+500 エラー例:
+
+```json
+{
+  "error": "Internal Server Error",
+  "code": "INTERNAL_ERROR"
+}
+```
 
 ## 🧭 ロードマップ / 改善予定
 

--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ For backward compatibility, `GET /todos?boardId=<id>` returns the same result. B
 
 ### Refresh token reuse detection (#77)
 
-When a rotated/revoked refresh token is replayed, `/auth/refresh` returns `403` with `errorCode: "REFRESH_TOKEN_REUSE"`.
+When a rotated/revoked refresh token is replayed, `/auth/refresh` returns `403` with `code: "REFRESH_TOKEN_REUSE"`.
 See: [docs/auth-refresh-token-reuse.md](./docs/auth-refresh-token-reuse.md)
 
 ## 🗂️ Project Structure
@@ -370,11 +370,13 @@ npm test        # run Jest + Supertest suites
 Targeted test execution:
 
 ```bash
-npx jest tests/todos.test.js --runInBand
-npx jest tests/smoke.e2e.test.js --runInBand
+npm run test:file -- tests/errors.test.js
+npm run test:file -- tests/todos.test.js
+npm run test:file -- tests/smoke.e2e.test.js
 ```
 
 Issue #7 test scope:
+- `tests/errors.test.js`: covers standardized `400 / 404 / 500` error responses.
 - `tests/todos.test.js`: covers Todo CRUD happy paths and a representative validation error.
 - `tests/smoke.e2e.test.js`: covers one end-to-end flow (`create -> list -> update -> delete`).
 - `tests/auth.test.js` still exists as a `node:test` suite and is run separately.
@@ -393,11 +395,39 @@ make seed
 
 ## ⚠️ Error Handling
 
-All errors are normalized through middlewares/error.js.
+Runtime API errors are normalized through `server/middlewares/error.js`.
 
-- Stack traces visible only in non-production mode.
-- Future improvement: unify async route handling with a global wrapper.
-- 400/404/500 responses are structured for frontend consumption.
+- All error responses follow `{ error, code, details? }`.
+- `details` is omitted when there is nothing to return.
+- 500 responses intentionally hide internal exception details from clients.
+
+Validation example:
+
+```json
+{
+  "error": "Validation error",
+  "code": "VALIDATION_ERROR",
+  "details": [{ "field": "title", "msg": "title is required" }]
+}
+```
+
+Not found example:
+
+```json
+{
+  "error": "Not found",
+  "code": "NOT_FOUND"
+}
+```
+
+Internal error example:
+
+```json
+{
+  "error": "Internal Server Error",
+  "code": "INTERNAL_ERROR"
+}
+```
 
 ## 🧭 Roadmap / Improvements
 

--- a/docs/auth-refresh-token-reuse.md
+++ b/docs/auth-refresh-token-reuse.md
@@ -18,7 +18,7 @@
 ```json
 {
   "error": "Refresh token reuse detected",
-  "errorCode": "REFRESH_TOKEN_REUSE"
+  "code": "REFRESH_TOKEN_REUSE"
 }
 ```
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,9 @@
 export default {
   testEnvironment: 'node',
-  testMatch: ['**/tests/todos.test.js', '**/tests/smoke.e2e.test.js', '**/tests/cors.test.js'],
+  testMatch: [
+    '**/tests/todos.test.js',
+    '**/tests/smoke.e2e.test.js',
+    '**/tests/cors.test.js',
+    '**/tests/errors.test.js',
+  ],
 };

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "nodemon server/server.js",
     "lint": "eslint .",
     "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand",
+    "test:file": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --runTestsByPath",
     "migrate:token-reuse-77": "node scripts/migrations/20260223-token-reuse-detection-77.js"
   },
   "dependencies": {

--- a/server/app.js
+++ b/server/app.js
@@ -15,6 +15,16 @@ import config from './config/index.js';
 import buildCspDirectives from './config/csp.js';
 import { createCorsOptions } from './config/cors.js';
 import openapiSpec from './config/openapi.js';
+import { createHttpError, createNotFoundError } from './utils/http-errors.js';
+
+function handleRateLimitExceeded(_req, _res, next, options) {
+  const message =
+    typeof options.message === 'string'
+      ? options.message
+      : 'Too many requests, please try again later.';
+
+  return next(createHttpError(options.statusCode || 429, message, 'RATE_LIMIT_EXCEEDED'));
+}
 
 export function createApp() {
   const app = express();
@@ -43,6 +53,7 @@ export function createApp() {
     max: 100,
     message: 'Too many requests, please try again later.',
     skip: (req) => req.path === '/health',
+    handler: handleRateLimitExceeded,
   });
   app.use(limiter);
 
@@ -88,6 +99,8 @@ export function createApp() {
   app.use('/todos', todosRouter);
   app.use('/boards', boardsRouter);
   app.use('/', userRoutes);
+
+  app.use((_req, _res, next) => next(createNotFoundError()));
 
   // --- エラーハンドラ ---
   app.use(errorHandler);

--- a/server/controllers/auth.controller.js
+++ b/server/controllers/auth.controller.js
@@ -5,20 +5,27 @@ import {
   rotateRefreshToken,
   revokeRefreshToken,
 } from '../services/auth.service.js';
+import { createHttpError, createValidationError } from '../utils/http-errors.js';
 
 const TOKEN_TYPE = 'Bearer';
 
 export const validateRefresh = [
-  body('refreshToken').isString().trim().notEmpty().withMessage('refreshToken is required'),
+  body('refreshToken')
+    .exists({ checkFalsy: true })
+    .withMessage('refreshToken is required')
+    .bail()
+    .isString()
+    .withMessage('refreshToken must be a string')
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage('refreshToken is required'),
 ];
 
-export const handleValidation = (req, res, next) => {
+export const handleValidation = (req, _res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    return res.status(400).json({
-      error: 'Validation error',
-      details: errors.array(),
-    });
+    return next(createValidationError(errors.array()));
   }
   return next();
 };
@@ -32,7 +39,7 @@ export const refreshAccessToken = async (req, res, next) => {
     });
 
     if (payload.tokenType && payload.tokenType !== 'refresh') {
-      return res.status(401).json({ error: 'Invalid token' });
+      return next(createHttpError(401, 'Invalid token', 'INVALID_TOKEN'));
     }
 
     const { tokenType, iat, exp, nbf, iss, aud, sub, jti, ...userPayload } = payload;
@@ -45,10 +52,7 @@ export const refreshAccessToken = async (req, res, next) => {
     });
   } catch (e) {
     if (e.name === 'RefreshTokenReuseDetectedError') {
-      return res.status(e.status || 403).json({
-        error: e.message,
-        errorCode: e.errorCode || 'REFRESH_TOKEN_REUSE',
-      });
+      return next(e);
     }
 
     if (
@@ -56,7 +60,7 @@ export const refreshAccessToken = async (req, res, next) => {
       e.name === 'JsonWebTokenError' ||
       e.name === 'InvalidRefreshTokenError'
     ) {
-      return res.status(401).json({ error: 'Invalid token' });
+      return next(createHttpError(401, 'Invalid token', 'INVALID_TOKEN'));
     }
     return next(e);
   }
@@ -68,7 +72,7 @@ export const logout = async (req, res, next) => {
     const revoked = await revokeRefreshToken(refreshToken);
 
     if (!revoked) {
-      return res.status(401).json({ error: 'Invalid token' });
+      return next(createHttpError(401, 'Invalid token', 'INVALID_TOKEN'));
     }
 
     return res.status(204).send();
@@ -78,7 +82,7 @@ export const logout = async (req, res, next) => {
       e.name === 'JsonWebTokenError' ||
       e.name === 'InvalidRefreshTokenError'
     ) {
-      return res.status(401).json({ error: 'Invalid token' });
+      return next(createHttpError(401, 'Invalid token', 'INVALID_TOKEN'));
     }
     return next(e);
   }

--- a/server/controllers/boards.controller.js
+++ b/server/controllers/boards.controller.js
@@ -5,6 +5,7 @@
 // ============================================
 
 import * as boardService from '../services/boards.service.js';
+import { createHttpError } from '../utils/http-errors.js';
 
 // ============================================
 // 🔸 GET /boards - 認証済みユーザーのBoard一覧
@@ -12,7 +13,7 @@ import * as boardService from '../services/boards.service.js';
 export const getBoards = async (req, res, next) => {
   try {
     if (!req.user || !req.user.id) {
-      return res.status(401).json({ error: 'Unauthorized' });
+      return next(createHttpError(401, 'Unauthorized', 'UNAUTHORIZED'));
     }
 
     const boards = await boardService.getBoardsByOwnerId(String(req.user.id));
@@ -22,8 +23,8 @@ export const getBoards = async (req, res, next) => {
       createdAt: board.createdAt,
     }));
 
-    res.json({ boards: payload });
+    return res.json({ boards: payload });
   } catch (e) {
-    next(e);
+    return next(e);
   }
 };

--- a/server/controllers/todos.controller.js
+++ b/server/controllers/todos.controller.js
@@ -10,6 +10,7 @@ import { body, validationResult } from 'express-validator';
 
 // サービス層をインポート（DBとのやり取りはすべてここで実行）
 import * as todoService from '../services/todos.service.js';
+import { createNotFoundError, createValidationError } from '../utils/http-errors.js';
 
 // ============================================
 // 🔸 1. 入力チェック（バリデーションルール）
@@ -18,7 +19,12 @@ import * as todoService from '../services/todos.service.js';
 // 新規作成用
 export const validateCreate = [
   body('title') // titleフィールドを確認
+    .exists({ checkFalsy: true })
+    .withMessage('title is required')
+    .bail()
     .isString() // 文字列であること
+    .withMessage('title must be a string')
+    .bail()
     .trim() // 余計な空白を除去
     .notEmpty() // 空でないこと
     .withMessage('title is required'), // 条件を満たさなければエラーメッセージ
@@ -41,7 +47,14 @@ export const validateCreate = [
 
 // 更新用
 export const validateUpdate = [
-  body('title').optional().isString().trim().notEmpty(),
+  body('title')
+    .optional()
+    .isString()
+    .withMessage('title must be a string')
+    .bail()
+    .trim()
+    .notEmpty()
+    .withMessage('title is required'),
   body('status').optional().isIn(['pending', 'in-progress', 'completed']),
   body('priority')
     .optional()
@@ -58,30 +71,26 @@ export const validateUpdate = [
 // 🔸 2. 共通バリデーションチェック
 // ============================================
 // ↑ のルールを通った後で、実際に問題があるか確認する関数。
-export const handleValidation = (req, res, next) => {
+export const handleValidation = (req, _res, next) => {
   const errors = validationResult(req);
   if (!errors.isEmpty()) {
-    // エラーがある場合はHTTP 400（Bad Request）で返す
-    return res.status(400).json({
-      error: 'Validation error',
-      details: errors.array(),
-    });
+    return next(createValidationError(errors.array()));
   }
   // 問題がなければ次の処理へ
-  next();
+  return next();
 };
 
 // ============================================
 // 🔸 3. CREATE（新しいTodoを追加）
 // ============================================
-export const createTodo = async (req, res) => {
+export const createTodo = async (req, res, next) => {
   try {
     // サービス層に実際の作成処理を依頼
     const todo = await todoService.createTodo(req.body);
     // 成功したら 201（Created）で返す
-    res.status(201).json(todo);
+    return res.status(201).json(todo);
   } catch (e) {
-    res.status(400).json({ error: e.message });
+    return next(e);
   }
 };
 
@@ -197,22 +206,30 @@ export const getTodosByBoardId = async (req, res, next) => {
 // ============================================
 // 🔸 5. UPDATE（既存Todoを更新）
 // ============================================
-export const updateTodo = async (req, res) => {
+export const updateTodo = async (req, res, next) => {
   try {
     const updated = await todoService.updateTodo(req.params.id, req.body);
-    if (!updated) return res.status(404).json({ error: 'Not found' });
-    res.json(updated);
+    if (!updated) {
+      return next(createNotFoundError());
+    }
+    return res.json(updated);
   } catch (e) {
-    res.status(400).json({ error: e.message });
+    return next(e);
   }
 };
 
 // ============================================
 // 🔸 6. DELETE（Todoを削除）
 // ============================================
-export const deleteTodo = async (req, res) => {
-  const deleted = await todoService.deleteTodo(req.params.id);
-  if (!deleted) return res.status(404).json({ error: 'Not found' });
-  // 削除成功時は 204 No Content
-  res.status(204).end();
+export const deleteTodo = async (req, res, next) => {
+  try {
+    const deleted = await todoService.deleteTodo(req.params.id);
+    if (!deleted) {
+      return next(createNotFoundError());
+    }
+    // 削除成功時は 204 No Content
+    return res.status(204).end();
+  } catch (e) {
+    return next(e);
+  }
 };

--- a/server/controllers/users.controller.js
+++ b/server/controllers/users.controller.js
@@ -4,17 +4,19 @@
 // 🔹 役割：ユーザー関連のリクエストを処理
 // ============================================
 
+import { createHttpError } from '../utils/http-errors.js';
+
 // ============================================
 // 🔸 GET /me - 認証済みユーザー情報を返す
 // ============================================
-export const getMe = async (req, res) => {
+export const getMe = async (req, res, next) => {
   // 認証ミドルウェアによって req.user に情報が格納されている前提
   if (!req.user) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return next(createHttpError(401, 'Unauthorized', 'UNAUTHORIZED'));
   }
 
   // Issue #26 で指定されたフィールドのみを返す
-  res.json({
+  return res.json({
     id: req.user.id,
     name: req.user.name,
     email: req.user.email,

--- a/server/middlewares/auth.js
+++ b/server/middlewares/auth.js
@@ -1,27 +1,28 @@
 // server/middlewares/auth.js
 import jwt from 'jsonwebtoken';
+import { createHttpError } from '../utils/http-errors.js';
 
-export default function auth(req, res, next) {
+export default function auth(req, _res, next) {
   const authHeader = req.headers.authorization || '';
   const [scheme, token] = authHeader.split(' ');
 
   if (scheme !== 'Bearer' || !token) {
-    return res.status(401).json({ error: 'Unauthorized' });
+    return next(createHttpError(401, 'Unauthorized', 'UNAUTHORIZED'));
   }
 
   const secret = process.env.JWT_SECRET;
   if (!secret) {
-    return res.status(500).json({ error: 'JWT_SECRET is not configured' });
+    return next(createHttpError(500, 'JWT_SECRET is not configured', 'INTERNAL_ERROR'));
   }
 
   try {
     const payload = jwt.verify(token, secret);
     if (payload.tokenType && payload.tokenType !== 'access') {
-      return res.status(401).json({ error: 'Invalid token' });
+      return next(createHttpError(401, 'Invalid token', 'INVALID_TOKEN'));
     }
     req.user = payload;
     return next();
-  } catch (err) {
-    return res.status(401).json({ error: 'Invalid token' });
+  } catch (_err) {
+    return next(createHttpError(401, 'Invalid token', 'INVALID_TOKEN'));
   }
 }

--- a/server/middlewares/error.js
+++ b/server/middlewares/error.js
@@ -1,11 +1,69 @@
 // server/middlewares/error.js
-export default function errorHandler(err, _req, res, _next) {
-  const status = err.status || 500;
-  const payload = { error: err.message || 'Internal Server Error' };
+import {
+  createHttpError,
+  getDefaultErrorCode,
+  getDefaultErrorMessage,
+  normalizeValidationDetails,
+} from '../utils/http-errors.js';
 
-  if (process.env.NODE_ENV !== 'production' && err.stack) {
-    payload.stack = err.stack;
+function fromMongooseValidationError(err) {
+  const details = normalizeValidationDetails(
+    Object.values(err.errors || {}).map((error) => ({
+      field: error.path,
+      msg: error.message,
+    }))
+  );
+
+  return createHttpError(400, 'Validation error', 'VALIDATION_ERROR', details);
+}
+
+function normalizeError(err) {
+  if (err?.name === 'ValidationError') {
+    return fromMongooseValidationError(err);
   }
 
-  res.status(status).json(payload);
+  if (err?.name === 'CastError') {
+    return createHttpError(400, 'Bad request', 'BAD_REQUEST');
+  }
+
+  if (err?.type === 'entity.parse.failed') {
+    return createHttpError(400, 'Bad request', 'BAD_REQUEST');
+  }
+
+  const status =
+    (Number.isInteger(err?.status) && err.status) ||
+    (Number.isInteger(err?.statusCode) && err.statusCode) ||
+    500;
+
+  const code =
+    (typeof err?.code === 'string' && err.code) ||
+    (typeof err?.errorCode === 'string' && err.errorCode) ||
+    getDefaultErrorCode(status);
+
+  const message =
+    status >= 500 ? getDefaultErrorMessage(500) : err?.message || getDefaultErrorMessage(status);
+
+  const normalized = createHttpError(status, message, code);
+
+  if (status < 500 && Array.isArray(err?.details) && err.details.length > 0) {
+    normalized.details = normalizeValidationDetails(err.details);
+  }
+
+  return normalized;
+}
+
+export default function errorHandler(err, _req, res, _next) {
+  const normalized = normalizeError(err);
+  const payload = {
+    error: normalized.message,
+    code: normalized.code,
+  };
+
+  if (normalized.details?.length) {
+    payload.details = normalized.details;
+  }
+
+  console.error('Error caught by middleware:', err);
+
+  res.status(normalized.status).json(payload);
 }

--- a/server/routes/todos.js
+++ b/server/routes/todos.js
@@ -71,15 +71,25 @@ router.use(auth);
  *       type: object
  *       required:
  *         - error
+ *         - code
  *       properties:
  *         error:
+ *           type: string
+ *         code:
  *           type: string
  *         details:
  *           type: array
  *           description: Present for validation errors.
  *           items:
  *             type: object
- *             additionalProperties: true
+ *             required:
+ *               - field
+ *               - msg
+ *             properties:
+ *               field:
+ *                 type: string
+ *               msg:
+ *                 type: string
  *     TodoListResponse:
  *       type: object
  *       required:

--- a/server/server.js
+++ b/server/server.js
@@ -15,6 +15,16 @@ import config from './config/index.js';
 import buildCspDirectives from './config/csp.js';
 import { createCorsOptions } from './config/cors.js';
 import openapiSpec from './config/openapi.js';
+import { createHttpError, createNotFoundError } from './utils/http-errors.js';
+
+function handleRateLimitExceeded(_req, _res, next, options) {
+  const message =
+    typeof options.message === 'string'
+      ? options.message
+      : 'Too many requests, please try again later.';
+
+  return next(createHttpError(options.statusCode || 429, message, 'RATE_LIMIT_EXCEEDED'));
+}
 
 console.log('🌱 NODE_ENV:', config.nodeEnv);
 
@@ -59,11 +69,13 @@ const generalLimiter = rateLimit({
   max: 100, // 各IPごとに最大100リクエスト
   message: 'Too many requests, please try again later.',
   skip: (req) => req.path === '/health',
+  handler: handleRateLimitExceeded,
 });
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15分
   max: 5, // 各IPごとに最大5リクエスト
   message: 'Too many authentication attempts, please try again later.',
+  handler: handleRateLimitExceeded,
 });
 app.use('/auth', authLimiter);
 app.use(generalLimiter);
@@ -111,6 +123,8 @@ app.use('/boards', boardsRouter);
 
 // userRoutes を登録
 app.use('/', userRoutes);
+
+app.use((_req, _res, next) => next(createNotFoundError()));
 
 // 共通エラーハンドラ（最後）
 app.use(errorHandler);

--- a/server/services/auth.service.js
+++ b/server/services/auth.service.js
@@ -41,12 +41,15 @@ export const hashRefreshToken = (token) => crypto.createHash('sha256').update(to
 const createInvalidRefreshTokenError = () => {
   const error = new Error('Invalid refresh token');
   error.name = 'InvalidRefreshTokenError';
+  error.status = 401;
+  error.code = 'INVALID_TOKEN';
   return error;
 };
 
 const createRefreshTokenReuseError = () => {
   const error = new Error('Refresh token reuse detected');
   error.name = 'RefreshTokenReuseDetectedError';
+  error.code = 'REFRESH_TOKEN_REUSE';
   error.errorCode = 'REFRESH_TOKEN_REUSE';
   error.status = 403;
   return error;

--- a/tests/auth.test.js
+++ b/tests/auth.test.js
@@ -68,7 +68,7 @@ describe('Auth refresh rotation and logout', () => {
     assert.equal(newToken.familyId, oldToken.familyId);
 
     const reuse = await request(app).post('/auth/refresh').send({ refreshToken }).expect(403);
-    assert.equal(reuse.body.errorCode, 'REFRESH_TOKEN_REUSE');
+    assert.equal(reuse.body.code, 'REFRESH_TOKEN_REUSE');
   });
 
   test('logout revokes the refresh token', async () => {
@@ -77,7 +77,7 @@ describe('Auth refresh rotation and logout', () => {
     await request(app).post('/auth/logout').send({ refreshToken }).expect(204);
 
     const reuse = await request(app).post('/auth/refresh').send({ refreshToken }).expect(403);
-    assert.equal(reuse.body.errorCode, 'REFRESH_TOKEN_REUSE');
+    assert.equal(reuse.body.code, 'REFRESH_TOKEN_REUSE');
   });
 
   test('reusing a rotated refresh token revokes all user tokens and records security event', async () => {
@@ -100,7 +100,7 @@ describe('Auth refresh rotation and logout', () => {
       .post('/auth/refresh')
       .send({ refreshToken: firstToken })
       .expect(403);
-    assert.equal(reuse.body.errorCode, 'REFRESH_TOKEN_REUSE');
+    assert.equal(reuse.body.code, 'REFRESH_TOKEN_REUSE');
     const decoded = jwt.decode(firstToken);
 
     const tokens = await RefreshToken.find({ userId: 'user-3' }).lean();
@@ -134,7 +134,7 @@ describe('Auth refresh rotation and logout', () => {
     await request(app).post('/auth/logout').send({ refreshToken }).expect(204);
 
     const reuse = await request(app).post('/auth/refresh').send({ refreshToken }).expect(403);
-    assert.equal(reuse.body.errorCode, 'REFRESH_TOKEN_REUSE');
+    assert.equal(reuse.body.code, 'REFRESH_TOKEN_REUSE');
 
     const tokens = await RefreshToken.find({ userId: 'user-4' }).lean();
     assert.ok(tokens.length >= 2);
@@ -154,6 +154,6 @@ describe('Auth refresh rotation and logout', () => {
       .post('/auth/refresh')
       .send({ refreshToken })
       .expect(403);
-    assert.equal(followupTokenReuse.body.errorCode, 'REFRESH_TOKEN_REUSE');
+    assert.equal(followupTokenReuse.body.code, 'REFRESH_TOKEN_REUSE');
   });
 });

--- a/tests/todos.test.js
+++ b/tests/todos.test.js
@@ -105,7 +105,10 @@ describe('Todos API', () => {
       .expect(400);
 
     expect(res.body.error).toBe('Validation error');
+    expect(res.body.code).toBe('VALIDATION_ERROR');
     expect(Array.isArray(res.body.details)).toBe(true);
-    expect(res.body.details.length).toBeGreaterThan(0);
+    expect(res.body.details).toEqual(
+      expect.arrayContaining([{ field: 'title', msg: 'title is required' }])
+    );
   });
 });


### PR DESCRIPTION
## Summary
Standardize API error responses into the format:
`{ error, code, details? }`

## Changes
- added shared HTTP error helpers
- normalized validation errors to `{ field, msg }`
- added 404 fallback in app/server
- changed controllers/middleware to prefer `next(err)`
- updated README and tests
- added `test:file` script for ESM Jest single-file runs

## Verified
- tests/errors.test.js
- tests/todos.test.js
- tests/smoke.e2e.test.js
- tests/auth.test.js

close #4